### PR TITLE
Fix of phase averaging with 'average' option

### DIFF
--- a/src/V_ANALYTIC.f90
+++ b/src/V_ANALYTIC.f90
@@ -120,7 +120,7 @@ contains
          mxphz=0
          cc=0
          do i=1,nm
-            phzi= -dobsi(i)/dobs(i)
+            phzi= -dobsi(i)
            
             if(phzi>0) then
                if(phzi>mxphz) mxphz=phz

--- a/src/V_ANALYTIC.f90
+++ b/src/V_ANALYTIC.f90
@@ -123,8 +123,8 @@ contains
             phzi= -dobsi(i)
            
             if(phzi>0) then
-               if(phzi>mxphz) mxphz=phz
-               if(phzi<mnphz) mnphz=phz
+               if(phzi>mxphz) mxphz=phzi
+               if(phzi<mnphz) mnphz=phzi
                phz=phz+phzi
                cc=cc+1
             end if


### PR DESCRIPTION
Phase averaging previously used a sum of the following:
```
phz=0
mnphz=1e30
mxphz=0
cc=0
do i=1,nm
  phzi= -dobsi(i)/dobs(i)
  if(phzi>0) then
      if(phzi>mxphz) mxphz=phz
      if(phzi<mnphz) mnphz=phz
      phz=phz+phzi
      cc=cc+1
  end if
end do
mean_phase=phz/cc
sigmai=tan(mean_phase)*sigma
```
There are two issues here:

1.  The phase is set to [observed apparant phase] divided by [observed transfer resistance]. For low resistances but relativly normal observed apparant phase, the calculated phase becomes massive. For real survey data I've tried it on and the two_blocks tutorial model (with a modelled response or an arbitrary constant value >= 1mRad) the value of mean_phase is then absurdly large. Taking the tan of this can then put the value of sigmai negative (if the value is between pi/2 & pi, or  3pi/2 &2pi, etc), or just way too high (in the hundreds of milli radians). When sigmai is negative this may be creating the [issue raised here](https://github.com/pnnl/E4D/issues/12) when E4D tries to take the logarithm of negative imaginary conductivities/phases when calculating the model norm.

2. mxphz and mnphz are set to the value of the sum at that point, rather than the value of phzi itself.

Hence the two simple changes of:
```
phzi=-dobsi(i)
```
and
```
if(phzi>mxphz) mxphz=phzi
if(phzi<mnphz) mnphz=phzi
```

Perhaps there may be a better way of performing the average (doing a weighted average based on the geometric factor of the measurement?), but for now this at least works.
